### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/ScriptBlocks/scriptblocks.github.io/security/code-scanning/3](https://github.com/ScriptBlocks/scriptblocks.github.io/security/code-scanning/3)

To resolve the issue, you need to add a `permissions` block to the workflow file `.github/workflows/build.yml`. This can be added either at the workflow root or at the job level (inside the `build:` job block). It is typically clearer to add it to the job that needs permissions if other jobs in the workflow do not need the same permissions. For this specific workflow, only the `build` job exists, and its purpose includes deploying to GitHub Pages, which requires `contents: write` privilege. Therefore, we should add `permissions: contents: write` inside the `build:` job block above `runs-on: ubuntu-latest`. This change ensures that the workflow only gets the minimal permissions required and removes the CodeQL error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
